### PR TITLE
fix: Added missing requirements and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Virtuel environment
+venv
+
+# Python
+*.pyc
+
+# Logs
+*.log

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ sentence_transformers
 faiss-cpu
 streamlit
 plotly
+langchain
+anthropic


### PR DESCRIPTION
Tried to set-up and run the repo on a fresh env, had missing requirements `langhcain` and `anthropic`.

What I did:
1. Added the missing requirements
2. Added a base `.gitignore` 

What should be done further:
1. Improve the README: After installing the requirements, there's still some env variables to be set, so adding this stuff to the README would be better for setup. I get the error below related to the `GROQ_API_KEY`:

```bash
GroqError: The api_key client option must be set either by passing api_key to the client or by setting the GROQ_API_KEY environment variable
Traceback:
File "/Users/atakantekparmak/Desktop/personal/MeeseeksAI/venv/lib/python3.12/site-packages/streamlit/runtime/scriptrunner/script_runner.py", line 600, in _run_script
    exec(code, module.__dict__)
File "/Users/atakantekparmak/Desktop/personal/MeeseeksAI/main.py", line 14, in <module>
    from src.agents import Agent
File "/Users/atakantekparmak/Desktop/personal/MeeseeksAI/src/agents.py", line 6, in <module>
    from src.clients import CLIENTS
File "/Users/atakantekparmak/Desktop/personal/MeeseeksAI/src/clients.py", line 74, in <module>
    CLIENTS = Clients()
              ^^^^^^^^^
File "/Users/atakantekparmak/Desktop/personal/MeeseeksAI/src/clients.py", line 15, in __init__
    self.groq = Groq(
                ^^^^^
File "/Users/atakantekparmak/Desktop/personal/MeeseeksAI/venv/lib/python3.12/site-packages/groq/_client.py", line 86, in __init__
    raise GroqError(
```